### PR TITLE
Add RoomTrackingKit Swift package

### DIFF
--- a/Packages/RoomTrackingKit/Package.swift
+++ b/Packages/RoomTrackingKit/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "RoomTrackingKit",
+    platforms: [
+        .visionOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "RoomTrackingKit",
+            targets: ["RoomTrackingKit"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "RoomTrackingKit",
+            dependencies: [])
+    ]
+)

--- a/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomTrackingManager.swift
+++ b/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomTrackingManager.swift
@@ -1,0 +1,52 @@
+import ARKit
+import Foundation
+
+/// Manages a room-tracking ARKit session.
+@MainActor
+public final class RoomTrackingManager {
+    private var arSession = ARKitSession()
+    private var roomProvider = RoomTrackingProvider()
+
+    /// Called whenever the provider outputs a new `RoomAnchor`.
+    public var roomAnchorUpdateHandler: ((RoomAnchor) -> Void)?
+
+    /// Called when the provider's `DataProviderState` changes.
+    public var stateChangeHandler: ((DataProviderState) -> Void)?
+
+    public init() {}
+
+    /// Starts the ARKit session and begins collecting room updates.
+    public func startTracking() async throws {
+        guard RoomTrackingProvider.isSupported else { return }
+        try await arSession.run([roomProvider])
+
+        Task { await processAnchorUpdates() }
+        Task { await monitorProviderState() }
+    }
+
+    /// Stops the ARKit session and resets the provider.
+    public func stopTracking() {
+        arSession.stop()
+        arSession = ARKitSession()
+        roomProvider = RoomTrackingProvider()
+    }
+
+    // MARK: - Private helpers
+    private func processAnchorUpdates() async {
+        for await update in roomProvider.anchorUpdates {
+            roomAnchorUpdateHandler?(update.anchor)
+        }
+    }
+
+    private func monitorProviderState() async {
+        for await event in arSession.events {
+            switch event {
+            case .dataProviderStateChanged(let providers, let newState, _):
+                guard providers.contains(where: { $0 === roomProvider }) else { continue }
+                stateChangeHandler?(newState)
+            default:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new RoomTrackingKit Swift package targeting visionOS 2
- implement `RoomTrackingManager` to manage an ARKit session using `RoomTrackingProvider`

## Testing
- `swift test -c release` *(fails: Could not find Package.swift in this directory or any of its parent directories)*