### PR TITLE
Add Package.swift for RoomTrackingKit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PfizerOutdoCancer",
+    platforms: [
+        .visionOS(.v2)
+    ],
+    dependencies: [
+        .package(path: "Packages/RoomTrackingKit")
+    ],
+    targets: [
+        .testTarget(
+            name: "RoomTrackingKitTests",
+            dependencies: [
+                .product(name: "RoomTrackingKit", package: "RoomTrackingKit")
+            ],
+            path: "Packages/RoomTrackingKit/Tests/RoomTrackingKitTests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add Swift Package manifest

## Testing
- `swift test -l` *(fails: cannot find `Packages/RoomTrackingKit`)*