### PR TITLE
Add RoomTrackingKit test stub

### DIFF
--- a/Packages/RoomTrackingKit/Tests/RoomTrackingKitTests/RoomTrackingManagerTests.swift
+++ b/Packages/RoomTrackingKit/Tests/RoomTrackingKitTests/RoomTrackingManagerTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import RoomTrackingKit
+
+struct RoomTrackingManagerTests {
+    @Test func managerInitialState() {
+        let manager = RoomTrackingManager()
+        #expect(manager.roomAnchorUpdateHandler == nil)
+        #expect(manager.stateChangeHandler == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- create test bundle for RoomTrackingKit
- add a simple RoomTrackingManagerTests file

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*