### PR TITLE
Add basic room sharing over MultipeerConnectivity

### DIFF
--- a/Packages/RoomTrackingKit/Package.swift
+++ b/Packages/RoomTrackingKit/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RoomTrackingKit",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "RoomTrackingKit",
+            targets: ["RoomTrackingKit"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "RoomTrackingKit"),
+        .testTarget(
+            name: "RoomTrackingKitTests",
+            dependencies: ["RoomTrackingKit"]
+        ),
+    ]
+)

--- a/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomShareService.swift
+++ b/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomShareService.swift
@@ -1,0 +1,80 @@
+#if canImport(MultipeerConnectivity) && canImport(ARKit)
+import Foundation
+import ARKit
+import MultipeerConnectivity
+
+public struct SharedRoomAnchor: Codable {
+    public let identifier: UUID
+    public let transform: simd_float4x4
+}
+
+public final class RoomShareService: NSObject {
+    private let serviceType = "room-share"
+    private let peerID = MCPeerID(displayName: UUID().uuidString)
+    private let session: MCSession
+    private let advertiser: MCNearbyServiceAdvertiser
+    private let browser: MCNearbyServiceBrowser
+
+    public var receivedAnchorHandler: ((SharedRoomAnchor) -> Void)?
+
+    public override init() {
+        session = MCSession(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
+        advertiser = MCNearbyServiceAdvertiser(peer: peerID, discoveryInfo: nil, serviceType: serviceType)
+        browser = MCNearbyServiceBrowser(peer: peerID, serviceType: serviceType)
+        super.init()
+        session.delegate = self
+        advertiser.delegate = self
+        browser.delegate = self
+        advertiser.startAdvertisingPeer()
+        browser.startBrowsingForPeers()
+    }
+
+    public func broadcast(anchor: SharedRoomAnchor) {
+        guard !session.connectedPeers.isEmpty else { return }
+        if let data = try? JSONEncoder().encode(anchor) {
+            try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+        }
+    }
+}
+
+extension RoomShareService: MCSessionDelegate, MCNearbyServiceAdvertiserDelegate, MCNearbyServiceBrowserDelegate {
+    public func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {}
+
+    public func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        if let anchor = try? JSONDecoder().decode(SharedRoomAnchor.self, from: data) {
+            receivedAnchorHandler?(anchor)
+        }
+    }
+
+    public func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {}
+    public func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
+    public func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
+
+    public func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        invitationHandler(true, session)
+    }
+
+    public func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {}
+
+    public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+        browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
+    }
+
+    public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {}
+    public func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {}
+}
+#else
+import Foundation
+import simd
+
+public struct SharedRoomAnchor: Codable {
+    public let identifier: UUID
+    public let transform: simd_float4x4
+}
+
+public final class RoomShareService {
+    public init() {}
+    public var receivedAnchorHandler: ((SharedRoomAnchor) -> Void)?
+    public func broadcast(anchor: SharedRoomAnchor) {}
+}
+#endif

--- a/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomTrackingKit.swift
+++ b/Packages/RoomTrackingKit/Sources/RoomTrackingKit/RoomTrackingKit.swift
@@ -1,0 +1,3 @@
+public struct RoomTrackingKit {
+    public init() {}
+}

--- a/Packages/RoomTrackingKit/Tests/RoomTrackingKitTests/RoomTrackingKitTests.swift
+++ b/Packages/RoomTrackingKit/Tests/RoomTrackingKitTests/RoomTrackingKitTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import RoomTrackingKit
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}

--- a/PfizerOutdoCancer/Managers/RoomTrackingManager.swift
+++ b/PfizerOutdoCancer/Managers/RoomTrackingManager.swift
@@ -1,0 +1,36 @@
+#if canImport(ARKit) && canImport(MultipeerConnectivity)
+import Foundation
+import ARKit
+import RoomTrackingKit
+
+@Observable
+@MainActor
+final class RoomTrackingManager {
+    private let shareService: RoomShareService
+    private var anchors: [UUID: RoomAnchor] = [:]
+
+    init(shareService: RoomShareService = RoomShareService()) {
+        self.shareService = shareService
+        self.shareService.receivedAnchorHandler = { [weak self] shared in
+            Task { await self?.createAnchor(from: shared) }
+        }
+    }
+
+    func lock(anchor: RoomAnchor) {
+        anchors[anchor.id] = anchor
+        let shared = SharedRoomAnchor(identifier: anchor.id, transform: anchor.originFromAnchorTransform)
+        shareService.broadcast(anchor: shared)
+    }
+
+    private func createAnchor(from shared: SharedRoomAnchor) {
+        guard anchors[shared.identifier] == nil else { return }
+        let anchor = RoomAnchor(transform: shared.transform)
+        anchors[shared.identifier] = anchor
+    }
+}
+#else
+final class RoomTrackingManager {
+    init() {}
+    func lock(anchor: Any) {}
+}
+#endif


### PR DESCRIPTION
## Summary
- introduce new `RoomTrackingKit` package
- implement `RoomShareService` to broadcast anchors via MultipeerConnectivity
- add `RoomTrackingManager` for receiving anchors and creating matches

## Testing
- `swift build` in `Packages/RoomTrackingKit` *(fails: no such module 'simd')*